### PR TITLE
MAINT: Updates PyYAML fo fix a py37/gcc8 fault

### DIFF
--- a/client/constraints.txt
+++ b/client/constraints.txt
@@ -24,7 +24,7 @@ ptyprocess==0.5.2
 pycryptodome==3.6.6
 python-daemon==2.1.2
 python-dateutil==2.6.1
-PyYAML==3.12
+PyYAML==3.13
 requests==2.18.1
 stopit==1.1.1
 urllib3==1.21.1

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -18,6 +18,6 @@ psutil==5.2.2
 pycryptodome==3.6.6
 python-daemon==2.1.2
 python-dateutil==2.6.1
-PyYAML==3.12
+PyYAML==3.13
 requests==2.18.1
 stopit==1.1.1


### PR DESCRIPTION
Trying to build the PyYAML 3.12 wheel on a recent Arch with python 3.7 and GCC 8.2.1 resulted in a fantastically large gcc error log (which I can provide if you're interested).

Updating to PyYAML 3.13 fixed the issue in a testing venv for me.