### PR TITLE
Support xidlehook and additional i3 locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ var
 
 # manually add the PKGBUILD files
 arch
+
+# pyenv
+.python-version
+
+# direnv
+.envrc

--- a/client/plugins/screenlock.py
+++ b/client/plugins/screenlock.py
@@ -21,7 +21,7 @@ from penguindome.client import get_logger
 import penguindome.json as json
 from penguindome.plugin_tools import find_x_users, DBusUser, process_dict_iter
 
-valid_lockers = ('slock', 'i3lock')
+valid_lockers = ('slock', 'i3lock', 'i3lock-fancy', 'i3lock-fancy-rapid')
 valid_lockers_re = re.compile(r'^(?:' +
                               '|'.join(re.escape(l) for l in valid_lockers) +
                               r')(?:\s|$)')


### PR DESCRIPTION
On my system, my screen lock looks like this:

```
irl       1574     1  0 14:21 ?        00:00:00 xidlehook --not-when-fullscreen --not-when-audio --timer normal 180 xrandr --output eDP-1 --brightness .4; xrandr --output HDMI-1 --brightness .4 xrandr --output eDP-1 --brightness 1; xrandr --output HDMI-1 --brightness 1 --timer primary 20 i3lock-fancy-rapid 5 3  --timer normal 300 systemctl suspend
```

The `xidlehook_status()` function returns:

```
In [122]: xidlehook_status(user, display)                                                                                                                                                   
Out[122]: {'enabled': True, 'delay': 200}
```
