### PR TITLE
Fixed logbook missing version

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -11,7 +11,7 @@
 # the License.
 
 fasteners==0.14.1
-Logbook==1.4.3
+Logbook==1.4.3.post1
 netifaces==0.10.9
 pexpect==4.6.0
 psutil==5.4.8

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,7 +11,7 @@
 # the License.
 
 Flask==1.0.2
-Logbook==1.4.3
+Logbook==1.4.3.post1
 -e git://github.com/quantopian/MongoDBProxy.git#egg=mongodbproxy
 passlib==1.7.1
 pycryptodome==3.7.2


### PR DESCRIPTION
Logbook version `1.4.3` is missing from PyPI due to an error on the developer's part, you can see the issue and the developers comments [here](https://github.com/getlogbook/logbook/issues/295).

I've changed the `requirements.txt` to point to `1.4.3.post1` which appears to be a re-upload of the `1.4.3` package (as there was issues uploading it as named as `1.4.3`