### PR TITLE
SEC: bump psutil to 5.6.6 for CVE-2019-18874

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,9 +1,9 @@
 # Quantopian, Inc. licenses this file to you under the Apache License, Version
 # 2.0 (the "License"); you may not use this file except in compliance with the
 # License. You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -14,7 +14,7 @@ fasteners==0.14.1
 Logbook==1.4.3.post1
 netifaces==0.10.9
 pexpect==4.6.0
-psutil==5.4.8
+psutil==5.6.6
 pycryptodome==3.7.2
 python-daemon==2.2.0
 python-dateutil==2.7.5


### PR DESCRIPTION
Changelog: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst
Github issue for double free - https://github.com/giampaolo/psutil/pull/1616