### PR TITLE
GitHub git:// is deprecated

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,7 +12,7 @@
 
 Flask==1.0.2
 Logbook==1.4.3.post1
--e git://github.com/quantopian/MongoDBProxy.git#egg=mongodbproxy
+-e git+https://github.com/quantopian/MongoDBProxy.git#egg=mongodbproxy
 passlib==1.7.1
 pycryptodome==3.7.2
 pymongo==3.10.1


### PR DESCRIPTION
Fixes this error when building the docker file

```
  ERROR: Command errored out with exit status 128:
   command: git clone --filter=blob:none -q git://github.com/quantopian/MongoDBProxy.git /usr/src/app/var/server-venv/src/mongodbproxy
       cwd: None
  Complete output (3 lines):
  fatal: unable to connect to github.com:
  github.com[0: 140.82.121.4]: errno=Connection timed out
```