### PR TITLE
Do not run __init__.py

### DIFF
--- a/client/collect.py
+++ b/client/collect.py
@@ -49,6 +49,9 @@ log = get_logger('collect')
 
 def run_file(run_path, run_name, results, parse_output=True,
              delete_after_success=False, submit_failures=False):
+    if run_name == '__init__':
+        return
+
     log.debug('Running {}', run_path)
     with NamedTemporaryFile('w+') as stderr_file:
         try:


### PR DESCRIPTION
Fix crashes when running collect.py

```
[2022-07-05 11:47:36.546501] ERROR: penguindome-collect: Output of client/plugins/__init__.py failed to parse
[...]
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```