### PR TITLE
Add support for newer python versions

### DIFF
--- a/client/collect.py
+++ b/client/collect.py
@@ -145,8 +145,12 @@ def run_dir(dir_path, parse_output=True, delete_after_success=False,
             run_file(*args, **kwargs)
     for thread in threads:
         thread.join(timeout=thread_timeout)
-        if thread.isAlive():
-            log.error("Timeout executing {}", thread.name)
+        if hasattr(thread, 'is_alive'):
+            if thread.is_alive():
+                log.error("Timeout executing {}", thread.name)
+        else:
+            if thread.isAlive():
+                log.error("Timeout executing {}", thread.name)
     return results
 
 


### PR DESCRIPTION
isAlive() is deprecated and replaced by is_alive()

Keep both for backwards compability

Fixes
```
AttributeError: 'Thread' object has no attribute 'isAlive'. Did you mean: 'is_alive'?
```

Also included in #32 but that seems to be stale
https://github.com/quantopian/PenguinDome/pull/32/commits/68c38fb94ccaacc18ede06e4992df5d8c8e5ea57