### PR TITLE
Replace virtualenv by python3 -m venv, fix #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ PenguinDome also uses a bunch of Python packages, all of which are
 deployed into a private virtualenv on the clients and server using
 `pip` at install time.
 
+`virtualenv` are created with native `python3 -m venv` tool now.
+Existing `virtualenv` created previously with `virtualenv` continue
+to work as-is.
+
+The use of `netifaces` package in client plugins requires `pip` 
+to compile it, hence the requirement of ubuntu `python-dev` or 
+equivalent on *the client* side.
+
 There's a nascent attempt in the `arch` subdirectory to build Pacman
 client packages for Arch Linux, but these don't entirely work right
 now, so for the time being, Arch clients use the same deployment

--- a/client/arch-packages.txt
+++ b/client/arch-packages.txt
@@ -22,7 +22,7 @@ git
 lvm2
 psmisc
 python
-python-virtualenv
+python
 systemd
 tar
 util-linux

--- a/client/client-setup.sh
+++ b/client/client-setup.sh
@@ -36,7 +36,7 @@ elif [ "$ID_LIKE" = "archlinux" -o "$ID" = "arch" ]; then
 fi
 
 if [ ! -d $venv ]; then
-    virtualenv -p python3 $venv
+    python3 -m venv $venv
 fi
 
 for dir in $(find $venv -name site-packages); do

--- a/client/ubuntu-packages.txt
+++ b/client/ubuntu-packages.txt
@@ -26,5 +26,6 @@ systemd
 tar
 ubuntu-release-upgrader-core
 update-notifier-common
-virtualenv
+python3-venv
+python3-dev
 wireless-tools

--- a/server/arch-packages.txt
+++ b/server/arch-packages.txt
@@ -17,6 +17,6 @@ gnupg
 https://aur.archlinux.org/libgfshare.git
 openssl
 python
-python-virtualenv
+python
 systemd
 tar

--- a/server/server-setup.sh
+++ b/server/server-setup.sh
@@ -75,7 +75,7 @@ elif [ "$ID_LIKE" = "archlinux" ]; then
 fi
 
 if [ ! -d $venv ]; then
-    virtualenv -p python3 $venv
+    python3 -m venv $venv
 fi
 
 for dir in $(find $venv -name site-packages); do

--- a/server/ubuntu-packages.txt
+++ b/server/ubuntu-packages.txt
@@ -18,4 +18,5 @@ openssl
 python3
 systemd
 tar
-virtualenv
+python3-venv
+python3-dev


### PR DESCRIPTION
I reported in this fork the tests I did on my test env, everything seems to work  fine.
Some already installed clients updated just fine and continued to work with venv previouly created with virtualenv.

Documentation may require a bit of attention.

Also I have not tested Arch, according to doc there's no `-dev` package so python headers are included ... but sot user pip will compile things all right.

I can get my hands on a arch VM to make a quick test I think.